### PR TITLE
bugfix - use 'tod' as shorthand for today

### DIFF
--- a/todolist/parser.go
+++ b/todolist/parser.go
@@ -61,7 +61,7 @@ func (p *Parser) Due(input string, day time.Time) string {
 	switch res {
 	case "none":
 		return ""
-	case "today":
+	case "today", "tod":
 		return now.BeginningOfDay().Format("2006-01-02")
 	case "tomorrow", "tom":
 		return now.BeginningOfDay().AddDate(0, 0, 1).Format("2006-01-02")

--- a/todolist/parser_test.go
+++ b/todolist/parser_test.go
@@ -59,11 +59,19 @@ func TestDueToday(t *testing.T) {
 	if todo.Due != now.BeginningOfDay().Format("2006-01-02") {
 		fmt.Println("Date is different", todo.Due, time.Now())
 	}
+	todo = parser.ParseNewTodo("do this thing with @bob and @mary due tod")
+	if todo.Due != now.BeginningOfDay().Format("2006-01-02") {
+		fmt.Println("Date is different", todo.Due, time.Now())
+	}
 }
 
 func TestDueTomorrow(t *testing.T) {
 	parser := &Parser{}
 	todo := parser.ParseNewTodo("do this thing with @bob and @mary due tomorrow")
+	if todo.Due != now.BeginningOfDay().AddDate(0, 0, 1).Format("2006-01-02") {
+		fmt.Println("Date is different", todo.Due, time.Now())
+	}
+	todo = parser.ParseNewTodo("do this thing with @bob and @mary due tom")
 	if todo.Due != now.BeginningOfDay().AddDate(0, 0, 1).Format("2006-01-02") {
 		fmt.Println("Date is different", todo.Due, time.Now())
 	}


### PR DESCRIPTION
The docs say that using `tod` is acceptable, but it would cause todolist to blow up.  This fixes things.