### PR TITLE
Fix file store location to only reference the users home dir

### DIFF
--- a/todolist/file_store.go
+++ b/todolist/file_store.go
@@ -15,13 +15,13 @@ type FileStore struct {
 
 func NewFileStore() *FileStore {
 	usr, err := user.Current()
-	if err = nil {
+	if err != nil {
 		fmt.Println("No user found from os")
 		return nil
 	}
 	return &FileStore{
-		FileLocation: fmt.Sprintf("%s/.todos.json", user.HomeDir),
-		Loaded: false,
+		FileLocation: fmt.Sprintf("%s/.todos.json", usr.HomeDir),
+		Loaded:       false,
 	}
 }
 

--- a/todolist/file_store.go
+++ b/todolist/file_store.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/user"
 )
 
 type FileStore struct {
@@ -13,7 +14,15 @@ type FileStore struct {
 }
 
 func NewFileStore() *FileStore {
-	return &FileStore{FileLocation: ".todos.json", Loaded: false}
+	usr, err := user.Current()
+	if err = nil {
+		fmt.Println("No user found from os")
+		return nil
+	}
+	return &FileStore{
+		FileLocation: fmt.Sprintf("%s/.todos.json", user.HomeDir),
+		Loaded: false,
+	}
 }
 
 func (f *FileStore) Load() ([]*Todo, error) {


### PR DESCRIPTION
This PR fixes issue #12 , which will allow todolist to be run from any directory.

@gammons I think this is the best approach, having a single persistent file in the home dir, rather than different todolists in different directories. If we/you wanted to keep the functionality of separate todolists, perhaps a flag could passed in to todolist init to create a local/relative todolist rather than a global one.

Let me know what you think.
