### PR TITLE
Use canonical form of travis build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Todolist
 
 [![](https://goreportcard.com/badge/github.com/gammons/todolist)](https://goreportcard.com/report/github.com/gammons/todolist)
-![](https://travis-ci.org/gammons/todolist.svg)
+[![Build Status](https://travis-ci.org/gammons/todolist.svg?branch=master)](https://travis-ci.org/gammons/todolist)
 
 Todolist is a simple and very fast task manager for the command line.  It is based on the [Getting Things Done][gtd] methodology.
 


### PR DESCRIPTION
The build badge link redirects to a static image. This PR will make clicking the link redirect to the travis build page for this project.