### PR TITLE
Bugfix: "todo a" no longer adds an empty todo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Todolist
 
 [![](https://goreportcard.com/badge/github.com/gammons/todolist)](https://goreportcard.com/report/github.com/gammons/todolist)
-![](https://travis-ci.org/gammons/todolist.svg)
+[![Build Status](https://travis-ci.org/gammons/todolist.svg?branch=master)](https://travis-ci.org/gammons/todolist)
 
 Todolist is a simple and very fast task manager for the command line.  It is based on the [Getting Things Done][gtd] methodology.
 

--- a/todolist/app.go
+++ b/todolist/app.go
@@ -25,6 +25,10 @@ func (a *App) AddTodo(input string) {
 	a.Load()
 	parser := &Parser{}
 	todo := parser.ParseNewTodo(input)
+	if todo == nil {
+		fmt.Println("What to do?")
+		return
+	}
 
 	a.TodoList.Add(todo)
 	a.Save()

--- a/todolist/app.go
+++ b/todolist/app.go
@@ -26,7 +26,7 @@ func (a *App) AddTodo(input string) {
 	parser := &Parser{}
 	todo := parser.ParseNewTodo(input)
 	if todo == nil {
-		fmt.Println("What to do?")
+		fmt.Println("I need more information. Try something like 'todo a chat with @bob due tom'")
 		return
 	}
 

--- a/todolist/parser.go
+++ b/todolist/parser.go
@@ -13,6 +13,12 @@ import (
 type Parser struct{}
 
 func (p *Parser) ParseNewTodo(input string) *Todo {
+	r, _ := regexp.Compile(`^(add|a)(\\ |)`)
+	input = r.ReplaceAllString(input, "")
+	if input == "" {
+		return nil
+	}
+
 	todo := NewTodo()
 	todo.Subject = p.Subject(input)
 	todo.Projects = p.Projects(input)
@@ -24,8 +30,6 @@ func (p *Parser) ParseNewTodo(input string) *Todo {
 }
 
 func (p *Parser) Subject(input string) string {
-	r, _ := regexp.Compile(`^(add|a) `)
-	input = r.ReplaceAllString(input, "")
 	if strings.Contains(input, " due") {
 		index := strings.LastIndex(input, " due")
 		return input[0:index]

--- a/todolist/parser_test.go
+++ b/todolist/parser_test.go
@@ -2,6 +2,7 @@ package todolist
 
 import (
 	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
@@ -81,7 +82,8 @@ func TestDueSpecific(t *testing.T) {
 	assert := assert.New(t)
 	parser := &Parser{}
 	todo := parser.ParseNewTodo("do this thing with @bob and @mary due jun 1")
-	assert.Equal("2016-06-01", todo.Due)
+	year := strconv.Itoa(time.Now().Year())
+	assert.Equal(fmt.Sprintf("%s-06-01", year), todo.Due)
 }
 
 func TestMondayOnSunday(t *testing.T) {
@@ -122,14 +124,16 @@ func TestTuesdayOnWednesday(t *testing.T) {
 func TestDueOnSpecificDate(t *testing.T) {
 	assert := assert.New(t)
 	parser := &Parser{}
-	assert.Equal("2016-05-02", parser.Due("due may 2", time.Now()))
-	assert.Equal("2016-06-01", parser.Due("due jun 1", time.Now()))
+	year := strconv.Itoa(time.Now().Year())
+	assert.Equal(fmt.Sprintf("%s-05-02", year), parser.Due("due may 2", time.Now()))
+	assert.Equal(fmt.Sprintf("%s-06-01", year), parser.Due("due jun 1", time.Now()))
 }
 
 func TestDueOnSpecificDateEuropean(t *testing.T) {
 	assert := assert.New(t)
 	parser := &Parser{}
-	assert.Equal("2016-05-02", parser.Due("due 2 may", time.Now()))
+	year := strconv.Itoa(time.Now().Year())
+	assert.Equal(fmt.Sprintf("%s-05-02", year), parser.Due("due 2 may", time.Now()))
 }
 
 func TestDueIntelligentlyChoosesCorrectYear(t *testing.T) {


### PR DESCRIPTION
The command `todo a` should not be treated as a todo item.  This patch move the pattern checking from `Parser.Subject()` to `Parser.ParseNewTodo()`, so that the condition can be detected before a todo item is allocated.