### PR TITLE
Fix delete subcommand to match website

### DIFF
--- a/todo.go
+++ b/todo.go
@@ -111,7 +111,7 @@ func routeInput(command string, input string) {
 		app.ListTodos(input)
 	case "a", "add":
 		app.AddTodo(input)
-	case "d", "del":
+	case "d", "delete":
 		app.DeleteTodo(input)
 	case "c", "complete":
 		app.CompleteTodo(input)


### PR DESCRIPTION
The website says to use `todolist delete` as the longhand way of deleting a task, so this brings the actual syntax to parity with that. This makes the pattern consistent for every other command, since they all have a single (or double) character shortcut and a fully spelled out longhand pattern.