### PR TITLE
Makes all output messages consistent

### DIFF
--- a/todolist/formatter.go
+++ b/todolist/formatter.go
@@ -62,7 +62,9 @@ func (f *Formatter) formatDue(due string) string {
 	dueTime, err := time.Parse("2006-01-02", due)
 
 	if err != nil {
-		panic(err)
+		fmt.Println(err)
+		fmt.Println("This may due to the corruption of .todos.json file.")
+		os.Exit(-1)
 	}
 
 	if isToday(dueTime) {

--- a/todolist/parser.go
+++ b/todolist/parser.go
@@ -2,6 +2,7 @@ package todolist
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -109,14 +110,21 @@ func (p *Parser) parseArbitraryDate(_date string, pivot time.Time) string {
 
 func (p *Parser) parseArbitraryDateWithYear(_date string, year int) time.Time {
 	res := strings.Join([]string{_date, strconv.Itoa(year)}, " ")
-	if date, err := time.Parse("Jan 2 2006", res); err == nil {
+	var date time.Time
+	var err1 error
+	var err2 error
+	if date, err1 = time.Parse("Jan 2 2006", res); err1 == nil {
 		return date
 	}
 
-	if date, err := time.Parse("2 Jan 2006", res); err == nil {
+	if date, err2 = time.Parse("2 Jan 2006", res); err2 == nil {
 		return date
 	}
-	panic(fmt.Errorf("Could not parse the date you gave me: '%s'", _date))
+	fmt.Printf("Could not parse the date you gave me: %s\n", _date)
+	fmt.Println(err1)
+	fmt.Println(err2)
+	os.Exit(-1)
+	return time.Now()
 }
 
 func (p *Parser) monday(day time.Time) string {

--- a/todolist/parser.go
+++ b/todolist/parser.go
@@ -110,19 +110,16 @@ func (p *Parser) parseArbitraryDate(_date string, pivot time.Time) string {
 
 func (p *Parser) parseArbitraryDateWithYear(_date string, year int) time.Time {
 	res := strings.Join([]string{_date, strconv.Itoa(year)}, " ")
-	var date time.Time
-	var err1 error
-	var err2 error
-	if date, err1 = time.Parse("Jan 2 2006", res); err1 == nil {
+	if date, err := time.Parse("Jan 2 2006", res); err == nil {
 		return date
 	}
 
-	if date, err2 = time.Parse("2 Jan 2006", res); err2 == nil {
+	if date, err := time.Parse("2 Jan 2006", res); err == nil {
 		return date
 	}
 	fmt.Printf("Could not parse the date you gave me: %s\n", _date)
-	fmt.Println(err1)
-	fmt.Println(err2)
+	fmt.Println("I'm expecting a date like \"Dec 22\" or \"22 Dec\".")
+	fmt.Println("See http://todolist.site/#adding for more info.")
 	os.Exit(-1)
 	return time.Now()
 }


### PR DESCRIPTION
Since the panic() function provides overwhelming messages available
for developers but meaningless to users, the way to deal with error
output is simplified. (referring to #19 )

There are two panic()'s that are fixed:

* The one in parseArbitraryDateWithYear() function.
  This function is the possible endpoint of adding a todo or editing
  dues.  Instead of calling panic(), now it outputs the specific
  parsing error, and then terminate itself by os.Exit().

* The one in formatDue() function
  This function is responsible for parsing the due information of a
  given todo.  If the todos being added previously have passed the
  checking, then there is no reason that a due fails the format
  check here, except for the corruption of the todo file.