### PR TITLE
Support UTF-8 strings as contexts and projects

### DIFF
--- a/todolist/formatter.go
+++ b/todolist/formatter.go
@@ -103,8 +103,8 @@ func (f *Formatter) formatSubject(subject string) string {
 	magenta := color.New(color.FgMagenta).SprintFunc()
 
 	splitted := strings.Split(subject, " ")
-	projectRegex, _ := regexp.Compile(`\+\w+`)
-	contextRegex, _ := regexp.Compile(`\@\w+`)
+	projectRegex, _ := regexp.Compile(`\+[\p{L}\d_]+`)
+	contextRegex, _ := regexp.Compile(`\@[\p{L}\d_]+`)
 
 	coloredWords := []string{}
 

--- a/todolist/parser.go
+++ b/todolist/parser.go
@@ -40,23 +40,24 @@ func (p *Parser) Subject(input string) string {
 }
 
 func (p *Parser) ExpandProject(input string) string {
-	r, _ := regexp.Compile(`(ex|expand) +\d+ +\+\w+[^:]`)
-	newProject := r.FindString(input)
-	if len(newProject) == 0 {
+	r, _ := regexp.Compile(`(ex|expand) +\d+ +\+[\p{L}\d_]+:`)
+	pattern := r.FindString(input)
+	if len(pattern) == 0 {
 		return ""
 	}
 
+	newProject := pattern[0 : len(pattern)-1]
 	project := strings.Split(newProject, " ")
 	return project[len(project)-1]
 }
 
 func (p *Parser) Projects(input string) []string {
-	r, _ := regexp.Compile(`\+\w+`)
+	r, _ := regexp.Compile(`\+[\p{L}\d_]+`)
 	return p.matchWords(input, r)
 }
 
 func (p *Parser) Contexts(input string) []string {
-	r, err := regexp.Compile(`\@\w+`)
+	r, err := regexp.Compile(`\@[\p{L}\d_]+`)
 	if err != nil {
 		fmt.Println("regex error", err)
 	}

--- a/todolist/parser_test.go
+++ b/todolist/parser_test.go
@@ -37,19 +37,24 @@ func TestParseExpandProjects(t *testing.T) {
 	assert.Equal("", wrongFormat2)
 	wrongFormat3 := parser.ExpandProject("ex 116 meeting figures, slides, coffee, suger")
 	assert.Equal("", wrongFormat3)
+	wrongFormat4 := parser.ExpandProject("ex 117 +重要な會議: 図, コーヒー, 砂糖")
+	assert.Equal("+重要な會議", wrongFormat4)
 }
 
 func TestParseProjects(t *testing.T) {
 	parser := &Parser{}
-	todo := parser.ParseNewTodo("do this thing +proj1 +proj2 due tomorrow")
-	if len(todo.Projects) != 2 {
-		t.Error("Expected Projects length to be 2")
+	todo := parser.ParseNewTodo("do this thing +proj1 +proj2 +專案3 due tomorrow")
+	if len(todo.Projects) != 3 {
+		t.Error("Expected Projects length to be 3")
 	}
 	if todo.Projects[0] != "proj1" {
 		t.Error("todo.Projects[0] should equal 'proj1' but got", todo.Projects[0])
 	}
 	if todo.Projects[1] != "proj2" {
 		t.Error("todo.Projects[1] should equal 'proj2' but got", todo.Projects[1])
+	}
+	if todo.Projects[2] != "專案3" {
+		t.Error("todo.Projects[2] should equal '專案3' but got", todo.Projects[2])
 	}
 }
 


### PR DESCRIPTION
While the "\w"-based pattern matching serves ASCII strings only, this patch extends the matching to UTF-8 strings for contexts and projects.
Two simple tests (in Traditional Chinese and Japanese) are added as well.