### PR TITLE
Revert "Global repo file as the default"

### DIFF
--- a/todolist/file_store.go
+++ b/todolist/file_store.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/user"
 )
 
 type FileStore struct {
@@ -14,36 +13,22 @@ type FileStore struct {
 }
 
 func NewFileStore() *FileStore {
-	localrepo := ".todos.json"
-	usr, _ := user.Current()
-	homerepo := fmt.Sprintf("%s/.todos.json", usr.HomeDir)
-	_, err1 := os.Stat(localrepo)
-	_, err2 := os.Stat(homerepo)
-
-	if err1 == nil {
-		return &FileStore{FileLocation: localrepo, Loaded: false}
-	} else if err2 == nil {
-		return &FileStore{FileLocation: homerepo, Loaded: false}
-	} else {
-		fmt.Println("No todo file found!")
-		fmt.Println("You may run 'todo init' to initialize an empty repo in working directory.")
-		os.Exit(1)
-		return nil
-	}
+	return &FileStore{FileLocation: ".todos.json", Loaded: false}
 }
 
 func (f *FileStore) Load() ([]*Todo, error) {
 	data, err := ioutil.ReadFile(f.FileLocation)
 	if err != nil {
-		fmt.Println("Error reading", f.FileLocation, "by", err)
+		fmt.Println("No todo file found!")
+		fmt.Println("Initialize a new todo repo by running 'todo init'")
 		return nil, err
-		os.Exit(1)
+		os.Exit(0)
 	}
 
 	var todos []*Todo
 	jerr := json.Unmarshal(data, &todos)
 	if jerr != nil {
-		fmt.Println("Error reading", f.FileLocation, "by", jerr)
+		fmt.Println("Error reading json data", jerr)
 		return nil, jerr
 		os.Exit(1)
 	}


### PR DESCRIPTION
Reverts gammons/todolist#32

@NonerKao after testing this locally for a while, I found a pretty critical bug.  It's impossible to run `todolist init` in a subdirectory, if you have `~/.todos.json`.  We need to remove the logic checks from `NewFileStore` and instead put them in the `Load` function instead.  That way, `Initialize` can still be called.