### PR TITLE
Adds support to projects with hyphen

### DIFF
--- a/todolist/parser.go
+++ b/todolist/parser.go
@@ -38,7 +38,7 @@ func (p *Parser) Subject(input string) string {
 }
 
 func (p *Parser) ExpandProject(input string) string {
-	r, _ := regexp.Compile(`(ex|expand) +\d+ +\+[\p{L}\d_]+:`)
+	r, _ := regexp.Compile(`(ex|expand) +\d+ +\+[\p{L}\d_-]+:`)
 	pattern := r.FindString(input)
 	if len(pattern) == 0 {
 		return ""
@@ -50,7 +50,7 @@ func (p *Parser) ExpandProject(input string) string {
 }
 
 func (p *Parser) Projects(input string) []string {
-	r, _ := regexp.Compile(`\+[\p{L}\d_]+`)
+	r, _ := regexp.Compile(`\+[\p{L}\d_-]+`)
 	return p.matchWords(input, r)
 }
 

--- a/todolist/parser_test.go
+++ b/todolist/parser_test.go
@@ -42,8 +42,8 @@ func TestParseExpandProjects(t *testing.T) {
 
 func TestParseProjects(t *testing.T) {
 	parser := &Parser{}
-	todo := parser.ParseNewTodo("do this thing +proj1 +proj2 +專案3 due tomorrow")
-	if len(todo.Projects) != 3 {
+	todo := parser.ParseNewTodo("do this thing +proj1 +proj2 +專案3 +proj-name due tomorrow")
+	if len(todo.Projects) != 4 {
 		t.Error("Expected Projects length to be 3")
 	}
 	if todo.Projects[0] != "proj1" {
@@ -54,6 +54,9 @@ func TestParseProjects(t *testing.T) {
 	}
 	if todo.Projects[2] != "專案3" {
 		t.Error("todo.Projects[2] should equal '專案3' but got", todo.Projects[2])
+	}
+	if todo.Projects[3] != "proj-name" {
+		t.Error("todo.Projects[3] should equal 'proj-name' but got", todo.Projects[3])
 	}
 }
 


### PR DESCRIPTION
Typing `todolist add foo +proj-name` would only identify `proj` as the project, ignoring `-name`.

This PR fixes this, so that `proj-name` is the identified project.