### PR TITLE
Edit subject

### DIFF
--- a/todo.go
+++ b/todo.go
@@ -140,8 +140,10 @@ func routeInput(command string, input string) {
 		app.UnarchiveTodo(input)
 	case "ac":
 		app.ArchiveCompleted()
-	case "e", "edit":
+	case "e", "edit", "ed", "edit-date":
 		app.EditTodoDue(input)
+	case "es", "edit-subject":
+		app.EditTodoSubject(input)
 	case "ex", "expand":
 		app.ExpandTodo(input)
 	case "gc":

--- a/todolist/app.go
+++ b/todolist/app.go
@@ -91,6 +91,18 @@ func (a *App) UnarchiveTodo(input string) {
 	fmt.Println("Todo unarchived.")
 }
 
+func (a *App) EditTodoSubject(input string) {
+	a.Load()
+	_, id, subject := Parser{input}.Parse()
+	id, todo := a.getId(input)
+	if id == -1 {
+		return
+	}
+	todo.Subject = subject
+	a.Save()
+	fmt.Println("Todo subject updated.")
+}
+
 func (a *App) EditTodoDue(input string) {
 	a.Load()
 	id, todo := a.getId(input)

--- a/todolist/app.go
+++ b/todolist/app.go
@@ -3,7 +3,6 @@ package todolist
 import (
 	"fmt"
 	"regexp"
-	"strconv"
 	"strings"
 	"time"
 )
@@ -174,19 +173,13 @@ func (a *App) UnprioritizeTodo(input string) {
 }
 
 func (a *App) getId(input string) (int, *Todo) {
-	re, _ := regexp.Compile("\\d+")
-	if re.MatchString(input) {
-		id, _ := strconv.Atoi(re.FindString(input))
-		todo := a.TodoList.FindById(id)
-		if todo == nil {
-			fmt.Println("No such id.")
-			return -1, nil
-		}
-		return id, todo
-	} else {
-		fmt.Println("Invalid id.")
+	_, id, _ := Parser{input}.Parse()
+	todo := a.TodoList.FindById(id)
+	if todo == nil {
+		fmt.Println("No such id.")
 		return -1, nil
 	}
+	return id, todo
 }
 
 func (a *App) getGroups(input string, todos []*Todo) *GroupedTodos {

--- a/todolist/app.go
+++ b/todolist/app.go
@@ -100,6 +100,10 @@ func (a *App) EditTodoSubject(input string) {
 	}
 
 	_, todo := a.getId(input)
+	if todo == nil {
+		fmt.Println("Todo not found.")
+		return
+	}
 	todo.Subject = subject
 
 	a.Save()

--- a/todolist/app.go
+++ b/todolist/app.go
@@ -101,7 +101,6 @@ func (a *App) EditTodoSubject(input string) {
 
 	_, todo := a.getId(input)
 	if todo == nil {
-		fmt.Println("Todo not found.")
 		return
 	}
 	todo.Subject = subject

--- a/todolist/app.go
+++ b/todolist/app.go
@@ -94,7 +94,8 @@ func (a *App) UnarchiveTodo(input string) {
 func (a *App) EditTodoSubject(input string) {
 	a.Load()
 
-	_, id, subject := Parser{input}.Parse()
+	p := Parser{input}
+	_, id, subject := p.Parse()
 	if id == -1 {
 		return
 	}
@@ -103,7 +104,10 @@ func (a *App) EditTodoSubject(input string) {
 	if todo == nil {
 		return
 	}
+
 	todo.Subject = subject
+	todo.Projects = p.Projects(subject)
+	todo.Contexts = p.Contexts(subject)
 
 	a.Save()
 	fmt.Println("Todo subject updated.")

--- a/todolist/app.go
+++ b/todolist/app.go
@@ -93,12 +93,15 @@ func (a *App) UnarchiveTodo(input string) {
 
 func (a *App) EditTodoSubject(input string) {
 	a.Load()
+
 	_, id, subject := Parser{input}.Parse()
-	id, todo := a.getId(input)
 	if id == -1 {
 		return
 	}
+
+	_, todo := a.getId(input)
 	todo.Subject = subject
+
 	a.Save()
 	fmt.Println("Todo subject updated.")
 }

--- a/todolist/parser.go
+++ b/todolist/parser.go
@@ -34,10 +34,14 @@ func (p Parser) Parse() (string, int, string) {
 	input := p.input
 	r := regexp.MustCompile(`(\w+) (\d+) (.*)`)
 	matches := r.FindStringSubmatch(input)
+	if len(matches) < 4 {
+		fmt.Println("Could match command, id or subject")
+		return "", -1, input
+	}
 	id, err := strconv.Atoi(matches[2])
 	if err != nil {
 		fmt.Println("Invalid id.")
-		id = -1
+		return "", -1, input
 	}
 
 	return matches[1], id, matches[3]

--- a/todolist/parser.go
+++ b/todolist/parser.go
@@ -9,7 +9,9 @@ import (
 	"time"
 )
 
-type Parser struct{}
+type Parser struct {
+	input string
+}
 
 func (p *Parser) ParseNewTodo(input string) *Todo {
 	r, _ := regexp.Compile(`^(add|a)(\\ |) `)
@@ -26,6 +28,19 @@ func (p *Parser) ParseNewTodo(input string) *Todo {
 		todo.Due = p.Due(input, time.Now())
 	}
 	return todo
+}
+
+func (p Parser) Parse() (string, int, string) {
+	input := p.input
+	r := regexp.MustCompile(`(\w+) (\d+) (.*)`)
+	matches := r.FindStringSubmatch(input)
+	id, err := strconv.Atoi(matches[2])
+	if err != nil {
+		fmt.Println("Invalid id.")
+		id = -1
+	}
+
+	return matches[1], id, matches[3]
 }
 
 func (p *Parser) Subject(input string) string {

--- a/todolist/parser.go
+++ b/todolist/parser.go
@@ -31,14 +31,16 @@ func (p *Parser) ParseNewTodo(input string) *Todo {
 }
 
 // Parse accepts user input and splits it into subcommand, the todo id to
-// work on and the input to the subcommand function.
-func (p Parser) Parse() (subcommand string, id int, input string) {
-	r := regexp.MustCompile(`(\w+)\s+(\d+)\s+(.*)`)
+// work on and the subject for the subcommand function.
+func (p Parser) Parse() (subcommand string, id int, subject string) {
+	r := regexp.MustCompile(`(\w+)\s+(\d+)(\s+(.*))?`)
 	matches := r.FindStringSubmatch(p.input)
-	if len(matches) < 4 {
-		fmt.Println("Could match command, id or subject")
+	if len(matches) < 3 {
+		fmt.Println("Could match command or id")
 		return "", -1, ""
 	}
+
+	subcommand = matches[1]
 
 	// because of the regexp match, this can never fail
 	id, err := strconv.Atoi(matches[2])
@@ -46,7 +48,11 @@ func (p Parser) Parse() (subcommand string, id int, input string) {
 		panic(err)
 	}
 
-	return matches[1], id, matches[3]
+	if len(matches) == 5 {
+		subject = matches[4]
+	}
+
+	return
 }
 
 func (p *Parser) Subject(input string) string {

--- a/todolist/parser.go
+++ b/todolist/parser.go
@@ -30,18 +30,20 @@ func (p *Parser) ParseNewTodo(input string) *Todo {
 	return todo
 }
 
-func (p Parser) Parse() (string, int, string) {
-	input := p.input
-	r := regexp.MustCompile(`(\w+) (\d+) (.*)`)
-	matches := r.FindStringSubmatch(input)
+// Parse accepts user input and splits it into subcommand, the todo id to
+// work on and the input to the subcommand function.
+func (p Parser) Parse() (subcommand string, id int, input string) {
+	r := regexp.MustCompile(`(\w+)\s+(\d+)\s+(.*)`)
+	matches := r.FindStringSubmatch(p.input)
 	if len(matches) < 4 {
 		fmt.Println("Could match command, id or subject")
-		return "", -1, input
+		return "", -1, ""
 	}
+
+	// because of the regexp match, this can never fail
 	id, err := strconv.Atoi(matches[2])
 	if err != nil {
-		fmt.Println("Invalid id.")
-		return "", -1, input
+		panic(err)
 	}
 
 	return matches[1], id, matches[3]

--- a/todolist/parser_test.go
+++ b/todolist/parser_test.go
@@ -169,3 +169,24 @@ func TestDueIntelligentlyChoosesCorrectYear(t *testing.T) {
 	assert.Equal("2017-01-10", parser.parseArbitraryDate("jan 10", septemberTime))
 	assert.Equal("2017-01-10", parser.parseArbitraryDate("jan 10", decemberTime))
 }
+
+func TestParseCommandIdSubject(t *testing.T) {
+	assert := assert.New(t)
+	parser := Parser{"es 24 a new subject"}
+	command, id, subject := parser.Parse()
+
+	assert.Equal("es", command)
+	assert.Equal(24, id)
+	assert.Equal("a new subject", subject)
+}
+
+func TestParseInvalidCommandIdSubject(t *testing.T) {
+	assert := assert.New(t)
+	input := "es a new project"
+	parser := Parser{input}
+	command, id, subject := parser.Parse()
+
+	assert.Equal("", command)
+	assert.Equal(-1, id)
+	assert.Equal(input, subject)
+}

--- a/todolist/parser_test.go
+++ b/todolist/parser_test.go
@@ -170,6 +170,16 @@ func TestDueIntelligentlyChoosesCorrectYear(t *testing.T) {
 	assert.Equal("2017-01-10", parser.parseArbitraryDate("jan 10", decemberTime))
 }
 
+func TestParseCommandIdSubjectWhitespace(t *testing.T) {
+	assert := assert.New(t)
+	parser := Parser{"es 24\t     a new subject"}
+	command, id, subject := parser.Parse()
+
+	assert.Equal("es", command)
+	assert.Equal(24, id)
+	assert.Equal("a new subject", subject)
+}
+
 func TestParseCommandIdSubject(t *testing.T) {
 	assert := assert.New(t)
 	parser := Parser{"es 24 a new subject"}
@@ -188,5 +198,5 @@ func TestParseInvalidCommandIdSubject(t *testing.T) {
 
 	assert.Equal("", command)
 	assert.Equal(-1, id)
-	assert.Equal(input, subject)
+	assert.Equal("", subject)
 }

--- a/todolist/parser_test.go
+++ b/todolist/parser_test.go
@@ -170,6 +170,16 @@ func TestDueIntelligentlyChoosesCorrectYear(t *testing.T) {
 	assert.Equal("2017-01-10", parser.parseArbitraryDate("jan 10", decemberTime))
 }
 
+func TestParseCommandIdSubjectOptionalSubject(t *testing.T) {
+	assert := assert.New(t)
+	parser := Parser{"d 24"}
+	command, id, subject := parser.Parse()
+
+	assert.Equal("d", command)
+	assert.Equal(24, id)
+	assert.Equal("", subject)
+}
+
 func TestParseCommandIdSubjectWhitespace(t *testing.T) {
 	assert := assert.New(t)
 	parser := Parser{"es 24\t     a new subject"}


### PR DESCRIPTION
This PR aims to add a simple way to edit a todo's subject.
Use `todolist es 1 my new subject +project` to update a todo's subject.

See #50