### PR TITLE
Unified edit

### DIFF
--- a/todo.go
+++ b/todo.go
@@ -140,8 +140,10 @@ func routeInput(command string, input string) {
 		app.UnarchiveTodo(input)
 	case "ac":
 		app.ArchiveCompleted()
-	case "e", "edit":
+	case "e", "edit", "ed", "edit-date":
 		app.EditTodoDue(input)
+	case "es", "edit-subject":
+		app.EditTodoSubject(input)
 	case "ex", "expand":
 		app.ExpandTodo(input)
 	case "gc":

--- a/todo.go
+++ b/todo.go
@@ -140,10 +140,8 @@ func routeInput(command string, input string) {
 		app.UnarchiveTodo(input)
 	case "ac":
 		app.ArchiveCompleted()
-	case "e", "edit", "ed", "edit-date":
-		app.EditTodoDue(input)
-	case "es", "edit-subject":
-		app.EditTodoSubject(input)
+	case "e", "edit":
+		app.EditTodo(input)
 	case "ex", "expand":
 		app.ExpandTodo(input)
 	case "gc":

--- a/todolist/app.go
+++ b/todolist/app.go
@@ -91,6 +91,18 @@ func (a *App) UnarchiveTodo(input string) {
 	fmt.Println("Todo unarchived.")
 }
 
+func (a *App) EditTodoSubject(input string) {
+	a.Load()
+	_, id, subject := Parser{input}.Parse()
+	id, todo := a.getId(input)
+	if id == -1 {
+		return
+	}
+	todo.Subject = subject
+	a.Save()
+	fmt.Println("Todo subject updated.")
+}
+
 func (a *App) EditTodoDue(input string) {
 	a.Load()
 	id, todo := a.getId(input)

--- a/todolist/app.go
+++ b/todolist/app.go
@@ -3,8 +3,8 @@ package todolist
 import (
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
-	"time"
 )
 
 type App struct {
@@ -91,38 +91,18 @@ func (a *App) UnarchiveTodo(input string) {
 	fmt.Println("Todo unarchived.")
 }
 
-func (a *App) EditTodoSubject(input string) {
+func (a *App) EditTodo(input string) {
 	a.Load()
-
-	p := Parser{input}
-	_, id, subject := p.Parse()
-	if id == -1 {
-		return
-	}
-
-	_, todo := a.getId(input)
-	if todo == nil {
-		return
-	}
-
-	todo.Subject = subject
-	todo.Projects = p.Projects(subject)
-	todo.Contexts = p.Contexts(subject)
-
-	a.Save()
-	fmt.Println("Todo subject updated.")
-}
-
-func (a *App) EditTodoDue(input string) {
-	a.Load()
-	id, todo := a.getId(input)
+	id, _ := a.getId(input)
 	if id == -1 {
 		return
 	}
 	parser := &Parser{}
-	todo.Due = parser.Due(input, time.Now())
-	a.Save()
-	fmt.Println("Todo due date updated.")
+
+	if (parser.ParseEditTodo(a.TodoList.FindById(id), input)) {
+		a.Save()
+		fmt.Println("Todo updated.")
+	}
 }
 
 func (a *App) ExpandTodo(input string) {
@@ -195,13 +175,22 @@ func (a *App) UnprioritizeTodo(input string) {
 }
 
 func (a *App) getId(input string) (int, *Todo) {
-	_, id, _ := Parser{input}.Parse()
-	todo := a.TodoList.FindById(id)
-	if todo == nil {
-		fmt.Println("No such id.")
+	re, _ := regexp.Compile("\\d+")
+	if re.MatchString(input) {
+		id, _ := strconv.Atoi(re.FindString(input))
+		todo := a.TodoList.FindById(id)
+		if todo == nil {
+			fmt.Println("No such id.")
+			return -1, nil
+
+		}
+		return id, todo
+
+	} else {
+		fmt.Println("Invalid id.")
 		return -1, nil
+
 	}
-	return id, todo
 }
 
 func (a *App) getGroups(input string, todos []*Todo) *GroupedTodos {

--- a/todolist/app.go
+++ b/todolist/app.go
@@ -3,7 +3,6 @@ package todolist
 import (
 	"fmt"
 	"regexp"
-	"strconv"
 	"strings"
 	"time"
 )
@@ -174,19 +173,13 @@ func (a *App) UnprioritizeTodo(input string) {
 }
 
 func (a *App) getId(input string) (int, *Todo) {
-	re, _ := regexp.Compile("\\d+")
-	if re.MatchString(input) {
-		id, _ := strconv.Atoi(re.FindString(input))
-		todo := a.TodoList.FindById(id)
-		if todo == nil {
-			fmt.Println("No such id.")
-			return -1, nil
-		}
-		return id, todo
-	} else {
-		fmt.Println("Invalid id.")
+	_, id, _ := Parser{input}.Parse()
+	todo := a.TodoList.FindById(id)
+	if todo == nil {
+		fmt.Println("No such id.")
 		return -1, nil
 	}
+	return id, todo
 }
 
 func (a *App) getGroups(input string, todos []*Todo) *GroupedTodos {

--- a/todolist/app.go
+++ b/todolist/app.go
@@ -93,13 +93,13 @@ func (a *App) UnarchiveTodo(input string) {
 
 func (a *App) EditTodo(input string) {
 	a.Load()
-	id, _ := a.getId(input)
+	id, todo := a.getId(input)
 	if id == -1 {
 		return
 	}
 	parser := &Parser{}
 
-	if (parser.ParseEditTodo(a.TodoList.FindById(id), input)) {
+	if (parser.ParseEditTodo(todo, input)) {
 		a.Save()
 		fmt.Println("Todo updated.")
 	}

--- a/todolist/app.go
+++ b/todolist/app.go
@@ -100,6 +100,10 @@ func (a *App) EditTodoSubject(input string) {
 	}
 
 	_, todo := a.getId(input)
+	if todo == nil {
+		fmt.Println("Todo not found.")
+		return
+	}
 	todo.Subject = subject
 
 	a.Save()

--- a/todolist/app.go
+++ b/todolist/app.go
@@ -101,7 +101,6 @@ func (a *App) EditTodoSubject(input string) {
 
 	_, todo := a.getId(input)
 	if todo == nil {
-		fmt.Println("Todo not found.")
 		return
 	}
 	todo.Subject = subject

--- a/todolist/app.go
+++ b/todolist/app.go
@@ -99,7 +99,7 @@ func (a *App) EditTodo(input string) {
 	}
 	parser := &Parser{}
 
-	if (parser.ParseEditTodo(todo, input)) {
+	if parser.ParseEditTodo(todo, input) {
 		a.Save()
 		fmt.Println("Todo updated.")
 	}

--- a/todolist/app.go
+++ b/todolist/app.go
@@ -94,7 +94,8 @@ func (a *App) UnarchiveTodo(input string) {
 func (a *App) EditTodoSubject(input string) {
 	a.Load()
 
-	_, id, subject := Parser{input}.Parse()
+	p := Parser{input}
+	_, id, subject := p.Parse()
 	if id == -1 {
 		return
 	}
@@ -103,7 +104,10 @@ func (a *App) EditTodoSubject(input string) {
 	if todo == nil {
 		return
 	}
+
 	todo.Subject = subject
+	todo.Projects = p.Projects(subject)
+	todo.Contexts = p.Contexts(subject)
 
 	a.Save()
 	fmt.Println("Todo subject updated.")

--- a/todolist/app.go
+++ b/todolist/app.go
@@ -93,12 +93,15 @@ func (a *App) UnarchiveTodo(input string) {
 
 func (a *App) EditTodoSubject(input string) {
 	a.Load()
+
 	_, id, subject := Parser{input}.Parse()
-	id, todo := a.getId(input)
 	if id == -1 {
 		return
 	}
+
+	_, todo := a.getId(input)
 	todo.Subject = subject
+
 	a.Save()
 	fmt.Println("Todo subject updated.")
 }

--- a/todolist/parser.go
+++ b/todolist/parser.go
@@ -34,10 +34,14 @@ func (p Parser) Parse() (string, int, string) {
 	input := p.input
 	r := regexp.MustCompile(`(\w+) (\d+) (.*)`)
 	matches := r.FindStringSubmatch(input)
+	if len(matches) < 4 {
+		fmt.Println("Could match command, id or subject")
+		return "", -1, input
+	}
 	id, err := strconv.Atoi(matches[2])
 	if err != nil {
 		fmt.Println("Invalid id.")
-		id = -1
+		return "", -1, input
 	}
 
 	return matches[1], id, matches[3]

--- a/todolist/parser.go
+++ b/todolist/parser.go
@@ -9,9 +9,7 @@ import (
 	"time"
 )
 
-type Parser struct {
-	input string
-}
+type Parser struct {}
 
 func (p *Parser) ParseNewTodo(input string) *Todo {
 	r, _ := regexp.Compile(`^(add|a)(\\ |) `)
@@ -30,29 +28,25 @@ func (p *Parser) ParseNewTodo(input string) *Todo {
 	return todo
 }
 
-// Parse accepts user input and splits it into subcommand, the todo id to
-// work on and the subject for the subcommand function.
-func (p Parser) Parse() (subcommand string, id int, subject string) {
+func (p *Parser) ParseEditTodo(todo *Todo, input string) bool {
 	r := regexp.MustCompile(`(\w+)\s+(\d+)(\s+(.*))?`)
-	matches := r.FindStringSubmatch(p.input)
+	matches := r.FindStringSubmatch(input)
 	if len(matches) < 3 {
 		fmt.Println("Could match command or id")
-		return "", -1, ""
+		return false
 	}
 
-	subcommand = matches[1]
+	subjectOnly := matches[3]
 
-	// because of the regexp match, this can never fail
-	id, err := strconv.Atoi(matches[2])
-	if err != nil {
-		panic(err)
+	if p.Subject(subjectOnly) != "" {
+		todo.Subject = p.Subject(subjectOnly)
+		todo.Projects = p.Projects(subjectOnly)
+		todo.Contexts = p.Contexts(subjectOnly)
 	}
-
-	if len(matches) == 5 {
-		subject = matches[4]
+	if p.hasDue(subjectOnly) {
+		todo.Due = p.Due(subjectOnly, time.Now())
 	}
-
-	return
+	return true
 }
 
 func (p *Parser) Subject(input string) string {

--- a/todolist/parser.go
+++ b/todolist/parser.go
@@ -9,7 +9,9 @@ import (
 	"time"
 )
 
-type Parser struct{}
+type Parser struct {
+	input string
+}
 
 func (p *Parser) ParseNewTodo(input string) *Todo {
 	r, _ := regexp.Compile(`^(add|a)(\\ |) `)
@@ -26,6 +28,19 @@ func (p *Parser) ParseNewTodo(input string) *Todo {
 		todo.Due = p.Due(input, time.Now())
 	}
 	return todo
+}
+
+func (p Parser) Parse() (string, int, string) {
+	input := p.input
+	r := regexp.MustCompile(`(\w+) (\d+) (.*)`)
+	matches := r.FindStringSubmatch(input)
+	id, err := strconv.Atoi(matches[2])
+	if err != nil {
+		fmt.Println("Invalid id.")
+		id = -1
+	}
+
+	return matches[1], id, matches[3]
 }
 
 func (p *Parser) Subject(input string) string {

--- a/todolist/parser.go
+++ b/todolist/parser.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-type Parser struct {}
+type Parser struct{}
 
 func (p *Parser) ParseNewTodo(input string) *Todo {
 	r, _ := regexp.Compile(`^(add|a)(\\ |) `)

--- a/todolist/parser.go
+++ b/todolist/parser.go
@@ -31,14 +31,16 @@ func (p *Parser) ParseNewTodo(input string) *Todo {
 }
 
 // Parse accepts user input and splits it into subcommand, the todo id to
-// work on and the input to the subcommand function.
-func (p Parser) Parse() (subcommand string, id int, input string) {
-	r := regexp.MustCompile(`(\w+)\s+(\d+)\s+(.*)`)
+// work on and the subject for the subcommand function.
+func (p Parser) Parse() (subcommand string, id int, subject string) {
+	r := regexp.MustCompile(`(\w+)\s+(\d+)(\s+(.*))?`)
 	matches := r.FindStringSubmatch(p.input)
-	if len(matches) < 4 {
-		fmt.Println("Could match command, id or subject")
+	if len(matches) < 3 {
+		fmt.Println("Could match command or id")
 		return "", -1, ""
 	}
+
+	subcommand = matches[1]
 
 	// because of the regexp match, this can never fail
 	id, err := strconv.Atoi(matches[2])
@@ -46,7 +48,11 @@ func (p Parser) Parse() (subcommand string, id int, input string) {
 		panic(err)
 	}
 
-	return matches[1], id, matches[3]
+	if len(matches) == 5 {
+		subject = matches[4]
+	}
+
+	return
 }
 
 func (p *Parser) Subject(input string) string {

--- a/todolist/parser.go
+++ b/todolist/parser.go
@@ -52,9 +52,9 @@ func (p *Parser) ParseEditTodo(todo *Todo, input string) bool {
 func (p *Parser) Subject(input string) string {
 	if strings.Contains(input, " due") {
 		index := strings.LastIndex(input, " due")
-		return input[0:index]
+		return strings.TrimSpace(input[0:index])
 	} else {
-		return input
+		return strings.TrimSpace(input)
 	}
 }
 

--- a/todolist/parser.go
+++ b/todolist/parser.go
@@ -30,18 +30,20 @@ func (p *Parser) ParseNewTodo(input string) *Todo {
 	return todo
 }
 
-func (p Parser) Parse() (string, int, string) {
-	input := p.input
-	r := regexp.MustCompile(`(\w+) (\d+) (.*)`)
-	matches := r.FindStringSubmatch(input)
+// Parse accepts user input and splits it into subcommand, the todo id to
+// work on and the input to the subcommand function.
+func (p Parser) Parse() (subcommand string, id int, input string) {
+	r := regexp.MustCompile(`(\w+)\s+(\d+)\s+(.*)`)
+	matches := r.FindStringSubmatch(p.input)
 	if len(matches) < 4 {
 		fmt.Println("Could match command, id or subject")
-		return "", -1, input
+		return "", -1, ""
 	}
+
+	// because of the regexp match, this can never fail
 	id, err := strconv.Atoi(matches[2])
 	if err != nil {
-		fmt.Println("Invalid id.")
-		return "", -1, input
+		panic(err)
 	}
 
 	return matches[1], id, matches[3]

--- a/todolist/parser.go
+++ b/todolist/parser.go
@@ -32,7 +32,7 @@ func (p *Parser) ParseEditTodo(todo *Todo, input string) bool {
 	r := regexp.MustCompile(`(\w+)\s+(\d+)(\s+(.*))?`)
 	matches := r.FindStringSubmatch(input)
 	if len(matches) < 3 {
-		fmt.Println("Could match command or id")
+		fmt.Println("Could not match command or id")
 		return false
 	}
 

--- a/todolist/parser_test.go
+++ b/todolist/parser_test.go
@@ -169,3 +169,24 @@ func TestDueIntelligentlyChoosesCorrectYear(t *testing.T) {
 	assert.Equal("2017-01-10", parser.parseArbitraryDate("jan 10", septemberTime))
 	assert.Equal("2017-01-10", parser.parseArbitraryDate("jan 10", decemberTime))
 }
+
+func TestParseCommandIdSubject(t *testing.T) {
+	assert := assert.New(t)
+	parser := Parser{"es 24 a new subject"}
+	command, id, subject := parser.Parse()
+
+	assert.Equal("es", command)
+	assert.Equal(24, id)
+	assert.Equal("a new subject", subject)
+}
+
+func TestParseInvalidCommandIdSubject(t *testing.T) {
+	assert := assert.New(t)
+	input := "es a new project"
+	parser := Parser{input}
+	command, id, subject := parser.Parse()
+
+	assert.Equal("", command)
+	assert.Equal(-1, id)
+	assert.Equal(input, subject)
+}

--- a/todolist/parser_test.go
+++ b/todolist/parser_test.go
@@ -170,43 +170,72 @@ func TestDueIntelligentlyChoosesCorrectYear(t *testing.T) {
 	assert.Equal("2017-01-10", parser.parseArbitraryDate("jan 10", decemberTime))
 }
 
-func TestParseCommandIdSubjectOptionalSubject(t *testing.T) {
+func TestParseEditTodoJustDate(t *testing.T) {
 	assert := assert.New(t)
-	parser := Parser{"d 24"}
-	command, id, subject := parser.Parse()
+	parser := &Parser{}
+	todo := NewTodo()
+	tomorrow := time.Now().AddDate(0,0,1).Format("2006-01-02")
 
-	assert.Equal("d", command)
-	assert.Equal(24, id)
-	assert.Equal("", subject)
+	parser.ParseEditTodo(todo, "e 24 due tom")
+
+	assert.Equal(todo.Due, tomorrow)
 }
 
-func TestParseCommandIdSubjectWhitespace(t *testing.T) {
+func TestParseEditTodoJustDateDoesNotEditExistingSubject(t *testing.T) {
 	assert := assert.New(t)
-	parser := Parser{"es 24\t     a new subject"}
-	command, id, subject := parser.Parse()
+	parser := &Parser{}
+	todo := NewTodo()
+	todo.Subject = "pick up the trash"
+	tomorrow := time.Now().AddDate(0,0,1).Format("2006-01-02")
 
-	assert.Equal("es", command)
-	assert.Equal(24, id)
-	assert.Equal("a new subject", subject)
+	parser.ParseEditTodo(todo, "e 24 due tom")
+
+	assert.Equal(todo.Due, tomorrow)
+	assert.Equal(todo.Subject, "pick up the trash")
 }
 
-func TestParseCommandIdSubject(t *testing.T) {
+func TestParseEditTodoJustSubject(t *testing.T) {
 	assert := assert.New(t)
-	parser := Parser{"es 24 a new subject"}
-	command, id, subject := parser.Parse()
+	parser := &Parser{}
+	todo := &Todo{Subject: "pick up the trash", Due: "2016-11-25"}
 
-	assert.Equal("es", command)
-	assert.Equal(24, id)
-	assert.Equal("a new subject", subject)
+	parser.ParseEditTodo(todo, "e 24 changed the todo")
+
+	assert.Equal(todo.Due, "2016-11-25")
+	assert.Equal(todo.Subject, "changed the todo")
 }
 
-func TestParseInvalidCommandIdSubject(t *testing.T) {
+func TestParseEditTodoSubjectUpdatesProjectsAndContexts(t *testing.T) {
 	assert := assert.New(t)
-	input := "es a new project"
-	parser := Parser{input}
-	command, id, subject := parser.Parse()
+	parser := &Parser{}
+	todo := &Todo{
+		Subject: "pick up the +trash with @dad",
+		Due: "2016-11-25",
+		Projects: []string{"trash"},
+		Contexts: []string{"dad"},
+	}
 
-	assert.Equal("", command)
-	assert.Equal(-1, id)
-	assert.Equal("", subject)
+	parser.ParseEditTodo(todo, "e 24 get the +garbage with @mom")
+
+	assert.Equal(todo.Due, "2016-11-25")
+	assert.Equal(todo.Subject, "get the +garbage with @mom")
+	assert.Equal(todo.Projects, []string{"garbage"})
+	assert.Equal(todo.Contexts, []string{"mom"})
+}
+
+func TestParseEditTodoWithSubjectAndDue(t *testing.T) {
+	assert := assert.New(t)
+	parser := &Parser{}
+	todo := &Todo{
+		Subject: "pick up the +trash with @dad",
+		Due: "2016-11-25",
+		Projects: []string{"trash"},
+		Contexts: []string{"dad"},
+	}
+	tomorrow := time.Now().AddDate(0,0,1).Format("2006-01-02")
+
+	parser.ParseEditTodo(todo, "e 24 get the +garbage with @mom due tom")
+
+	assert.Equal(todo.Due, tomorrow)
+	assert.Equal(todo.Subject, "get the +garbage with @mom")
 }

--- a/todolist/parser_test.go
+++ b/todolist/parser_test.go
@@ -174,7 +174,7 @@ func TestParseEditTodoJustDate(t *testing.T) {
 	assert := assert.New(t)
 	parser := &Parser{}
 	todo := NewTodo()
-	tomorrow := time.Now().AddDate(0,0,1).Format("2006-01-02")
+	tomorrow := time.Now().AddDate(0, 0, 1).Format("2006-01-02")
 
 	parser.ParseEditTodo(todo, "e 24 due tom")
 
@@ -186,7 +186,7 @@ func TestParseEditTodoJustDateDoesNotEditExistingSubject(t *testing.T) {
 	parser := &Parser{}
 	todo := NewTodo()
 	todo.Subject = "pick up the trash"
-	tomorrow := time.Now().AddDate(0,0,1).Format("2006-01-02")
+	tomorrow := time.Now().AddDate(0, 0, 1).Format("2006-01-02")
 
 	parser.ParseEditTodo(todo, "e 24 due tom")
 
@@ -209,8 +209,8 @@ func TestParseEditTodoSubjectUpdatesProjectsAndContexts(t *testing.T) {
 	assert := assert.New(t)
 	parser := &Parser{}
 	todo := &Todo{
-		Subject: "pick up the +trash with @dad",
-		Due: "2016-11-25",
+		Subject:  "pick up the +trash with @dad",
+		Due:      "2016-11-25",
 		Projects: []string{"trash"},
 		Contexts: []string{"dad"},
 	}
@@ -227,12 +227,12 @@ func TestParseEditTodoWithSubjectAndDue(t *testing.T) {
 	assert := assert.New(t)
 	parser := &Parser{}
 	todo := &Todo{
-		Subject: "pick up the +trash with @dad",
-		Due: "2016-11-25",
+		Subject:  "pick up the +trash with @dad",
+		Due:      "2016-11-25",
 		Projects: []string{"trash"},
 		Contexts: []string{"dad"},
 	}
-	tomorrow := time.Now().AddDate(0,0,1).Format("2006-01-02")
+	tomorrow := time.Now().AddDate(0, 0, 1).Format("2006-01-02")
 
 	parser.ParseEditTodo(todo, "e 24 get the +garbage with @mom due tom")
 

--- a/todolist/parser_test.go
+++ b/todolist/parser_test.go
@@ -170,6 +170,16 @@ func TestDueIntelligentlyChoosesCorrectYear(t *testing.T) {
 	assert.Equal("2017-01-10", parser.parseArbitraryDate("jan 10", decemberTime))
 }
 
+func TestParseCommandIdSubjectWhitespace(t *testing.T) {
+	assert := assert.New(t)
+	parser := Parser{"es 24\t     a new subject"}
+	command, id, subject := parser.Parse()
+
+	assert.Equal("es", command)
+	assert.Equal(24, id)
+	assert.Equal("a new subject", subject)
+}
+
 func TestParseCommandIdSubject(t *testing.T) {
 	assert := assert.New(t)
 	parser := Parser{"es 24 a new subject"}
@@ -188,5 +198,5 @@ func TestParseInvalidCommandIdSubject(t *testing.T) {
 
 	assert.Equal("", command)
 	assert.Equal(-1, id)
-	assert.Equal(input, subject)
+	assert.Equal("", subject)
 }

--- a/todolist/parser_test.go
+++ b/todolist/parser_test.go
@@ -170,6 +170,16 @@ func TestDueIntelligentlyChoosesCorrectYear(t *testing.T) {
 	assert.Equal("2017-01-10", parser.parseArbitraryDate("jan 10", decemberTime))
 }
 
+func TestParseCommandIdSubjectOptionalSubject(t *testing.T) {
+	assert := assert.New(t)
+	parser := Parser{"d 24"}
+	command, id, subject := parser.Parse()
+
+	assert.Equal("d", command)
+	assert.Equal(24, id)
+	assert.Equal("", subject)
+}
+
 func TestParseCommandIdSubjectWhitespace(t *testing.T) {
 	assert := assert.New(t)
 	parser := Parser{"es 24\t     a new subject"}


### PR DESCRIPTION
This allows a unified edit functionality that supports the following:

**`t e 25 due tom`**

* Edits the due date
* Leaves subject, projects and contexts unchanged

**`t e 25 take out the trash with @bob`**

* Updates the subject, projects and contexts
* Leaves the due date unchanged

**`t e 25 take out the trash with @bob due tom`**

* Updates the subject, projects and contexts
* Updates the due date

@mikezter I used parts of your PR, but I think I prefer if we head in this direction.  The `Parse` command did too much, I felt, and it was easy to model the edit functionality similar to how parser builds a brand new todo.  Let me know what you think.