### PR TITLE
Add list completed

### DIFF
--- a/todo.go
+++ b/todo.go
@@ -58,6 +58,14 @@ func usage() {
 	yellow.Println("\ttodo agenda")
 	fmt.Println("\tlists all todos where the due date is today or in the past\n")
 
+	fmt.Println("  todo l completed (tod|today|this week)")
+	cyan.Println("  Filtering by date:\n")
+
+	yellow.Println("\ttodo l completed (tod|today)")
+	fmt.Println("\tlists all todos that were completed today\n")
+	yellow.Println("\ttodo l completed this week")
+	fmt.Println("\tlists all todos that were completed this week\n")
+
 	cyan.Println("  Grouping:")
 	fmt.Println("  You can group todos by context or project.")
 	yellow.Println("\ttodo l by c")

--- a/todolist/date_filter.go
+++ b/todolist/date_filter.go
@@ -14,6 +14,10 @@ func NewDateFilter(todos []*Todo) *DateFilter {
 	return &DateFilter{Todos: todos, Location: time.Now().Location()}
 }
 
+func filterOnDue(todo *Todo) string {
+	return todo.Due
+}
+
 func (f *DateFilter) FilterDate(input string) []*Todo {
 	agendaRegex, _ := regexp.Compile(`agenda.*$`)
 	if agendaRegex.MatchString(input) {
@@ -24,9 +28,9 @@ func (f *DateFilter) FilterDate(input string) []*Todo {
 	match := r.FindString(input)
 	switch {
 	case match == "due tod" || match == "due today":
-		return f.filterToday(bod(time.Now()))
+		return f.filterDueToday(bod(time.Now()))
 	case match == "due tom" || match == "due tomorrow":
-		return f.filterTomorrow(bod(time.Now()))
+		return f.filterDueTomorrow(bod(time.Now()))
 	case match == "due sun" || match == "due sunday":
 		return f.filterDay(bod(time.Now()), time.Sunday)
 	case match == "due mon" || match == "due monday":
@@ -68,23 +72,23 @@ func (f *DateFilter) filterAgenda(pivot time.Time) []*Todo {
 	return ret
 }
 
-func (f *DateFilter) filterToExactDate(pivot time.Time) []*Todo {
+func (f *DateFilter) filterToExactDate(pivot time.Time, filterOn func(*Todo) string) []*Todo {
 	var ret []*Todo
 	for _, todo := range f.Todos {
-		if todo.Due == pivot.Format("2006-01-02") {
+		if filterOn(todo) == pivot.Format("2006-01-02") {
 			ret = append(ret, todo)
 		}
 	}
 	return ret
 }
 
-func (f *DateFilter) filterToday(pivot time.Time) []*Todo {
-	return f.filterToExactDate(pivot)
+func (f *DateFilter) filterDueToday(pivot time.Time) []*Todo {
+	return f.filterToExactDate(pivot, filterOnDue)
 }
 
-func (f *DateFilter) filterTomorrow(pivot time.Time) []*Todo {
+func (f *DateFilter) filterDueTomorrow(pivot time.Time) []*Todo {
 	pivot = pivot.AddDate(0, 0, 1)
-	return f.filterToExactDate(pivot)
+	return f.filterToExactDate(pivot, filterOnDue)
 }
 
 func (f *DateFilter) filterDay(pivot time.Time, day time.Weekday) []*Todo {

--- a/todolist/date_filter_test.go
+++ b/todolist/date_filter_test.go
@@ -17,7 +17,7 @@ func TestFilterToday(t *testing.T) {
 	todos = append(todos, tomorrowTodo)
 
 	filter := NewDateFilter(todos)
-	filtered := filter.filterToday(time.Now())
+	filtered := filter.filterDueToday(time.Now())
 
 	assert.Equal(1, len(filtered))
 	assert.Equal(1, filtered[0].Id)
@@ -33,7 +33,7 @@ func TestFilterTomorrow(t *testing.T) {
 	todos = append(todos, tomorrowTodo)
 
 	filter := NewDateFilter(todos)
-	filtered := filter.filterTomorrow(time.Now())
+	filtered := filter.filterDueTomorrow(time.Now())
 
 	assert.Equal(1, len(filtered))
 	assert.Equal(2, filtered[0].Id)

--- a/todolist/date_filter_test.go
+++ b/todolist/date_filter_test.go
@@ -39,6 +39,38 @@ func TestFilterTomorrow(t *testing.T) {
 	assert.Equal(2, filtered[0].Id)
 }
 
+func TestFilterCompletedToday(t *testing.T) {
+	assert := assert.New(t)
+
+	var todos []*Todo
+	todoNo1 := &Todo{Id: 1, Subject: "one", Due: time.Now().Format("2006-01-02")}
+	todoNo2 := &Todo{Id: 2, Subject: "two", Due: time.Now().Format("2006-01-02")}
+
+	todos = append(todos, todoNo1)
+	todos = append(todos, todoNo2)
+
+	filter := NewDateFilter(todos)
+	filtered := filter.filterCompletedToday(time.Now())
+
+	assert.Equal(0, len(filtered))
+
+	// now to complted one and see see what happens
+	todoNo1.Complete()
+	filtered = filter.filterCompletedToday(time.Now())
+
+	assert.Equal(1, len(filtered))
+	assert.Equal(1, filtered[0].Id)
+
+	// now to complted one and see see what happens
+	todoNo1.Uncomplete()
+	todoNo2.Complete()
+	filtered = filter.filterCompletedToday(time.Now())
+
+	assert.Equal(1, len(filtered))
+	assert.Equal(2, filtered[0].Id)
+
+}
+
 func TestFilterThisWeek(t *testing.T) {
 	assert := assert.New(t)
 
@@ -55,6 +87,30 @@ func TestFilterThisWeek(t *testing.T) {
 
 	assert.Equal(1, len(filtered))
 	assert.Equal(2, filtered[0].Id)
+}
+
+func TestFilterCompletedThisWeek(t *testing.T) {
+	assert := assert.New(t)
+
+	var todos []*Todo
+	lastWeekTodo := &Todo{Id: 1, Subject: "two", Due: time.Now().AddDate(0, 0, -7).Format("2006-01-02")}
+	todayTodo := &Todo{Id: 2, Subject: "one", Due: time.Now().Format("2006-01-02")}
+	nextWeekTodo := &Todo{Id: 3, Subject: "two", Due: time.Now().AddDate(0, 0, 8).Format("2006-01-02")}
+	todos = append(todos, lastWeekTodo)
+	todos = append(todos, todayTodo)
+	todos = append(todos, nextWeekTodo)
+
+	filter := NewDateFilter(todos)
+	filtered := filter.filterCompletedThisWeek(time.Now())
+
+	assert.Equal(0, len(filtered))
+
+	todayTodo.Complete()
+	filtered = filter.filterCompletedThisWeek(time.Now())
+
+	assert.Equal(1, len(filtered))
+	assert.Equal(2, filtered[0].Id)
+
 }
 
 func TestFilterOverdue(t *testing.T) {

--- a/todolist/date_filter_test.go
+++ b/todolist/date_filter_test.go
@@ -54,14 +54,12 @@ func TestFilterCompletedToday(t *testing.T) {
 
 	assert.Equal(0, len(filtered))
 
-	// now to complted one and see see what happens
 	todoNo1.Complete()
 	filtered = filter.filterCompletedToday(time.Now())
 
 	assert.Equal(1, len(filtered))
 	assert.Equal(1, filtered[0].Id)
 
-	// now to complted one and see see what happens
 	todoNo1.Uncomplete()
 	todoNo2.Complete()
 	filtered = filter.filterCompletedToday(time.Now())

--- a/todolist/filter.go
+++ b/todolist/filter.go
@@ -31,6 +31,13 @@ func (t *TodoFilter) isFilteringByContexts(input string) bool {
 }
 
 func (f *TodoFilter) filterArchived(input string) []*Todo {
+
+	// do not filter archived if want completed items
+	completedRegex, _ := regexp.Compile(`completed`)
+	if completedRegex.MatchString(input) {
+		return f.Todos
+	}
+
 	r, _ := regexp.Compile(`l archived$`)
 	if r.MatchString(input) {
 		return f.getArchived()

--- a/todolist/filter_test.go
+++ b/todolist/filter_test.go
@@ -30,6 +30,19 @@ func TestFilterUnarchivedByDefault(t *testing.T) {
 	assert.Equal(false, unarchived[0].Archived)
 }
 
+func TestFilterShowArchivedWhenWeAskForCompleted(t *testing.T) {
+	assert := assert.New(t)
+	store := &FileStore{FileLocation: "todos.json"}
+	list := &TodoList{}
+	todos, _ := store.Load()
+	list.Load(todos)
+	filter := NewFilter(list.Todos())
+	unarchived := filter.filterArchived("completed")
+	assert.Equal(2, len(unarchived))
+	assert.Equal(false, unarchived[0].Archived)
+	assert.Equal(true, unarchived[1].Archived)
+}
+
 func TestGetArchived(t *testing.T) {
 	assert := assert.New(t)
 	store := &FileStore{FileLocation: "todos.json"}

--- a/todolist/todo_item.go
+++ b/todolist/todo_item.go
@@ -44,3 +44,8 @@ func (t *Todo) Uncomplete() {
 	t.Completed = false
 	t.CompletedDate = ""
 }
+
+func (t Todo) CompletedDateToDate() string {
+	parsedTime, _ := time.Parse(ISO8601_TIMESTAMP_FORMAT, t.CompletedDate)
+	return parsedTime.Format("2006-01-02")
+}


### PR DESCRIPTION
This is a working implementation of #67. 

I have built upon my earlier work to reduce the redundancy  in the date_filter.go file, passing a function that supplies the date to filter on, either the Due date or the CompletedDate (minus the timestamp provided by CompletedDateToDate).  

I have renamed the filterToday and filterTomorrow for due filtering to filterDueToday and filterDueTomorrow respectively, in an effort to pass the focus of the filtering down to many levels.  (I am happy to amend this view point).  The reason I have not done this for  'filterThisWeek' is because I have another PR (#79) that will tidy this up a little.

The todolist.site might also need a little update if this is accepted too.