### PR TITLE
Fix a missed 't.Archive=true' to Archived()

### DIFF
--- a/todolist/app.go
+++ b/todolist/app.go
@@ -136,7 +136,7 @@ func (a *App) ArchiveCompleted() {
 	a.Load()
 	for _, todo := range a.TodoList.Todos() {
 		if todo.Completed {
-			todo.Archived = true
+			todo.Archive()
 		}
 	}
 	a.Save()


### PR DESCRIPTION
I missed this when moving the setting to the todo_item 