### PR TITLE
Fix a bug in ParseNewTodo()

### DIFF
--- a/todolist/app_test.go
+++ b/todolist/app_test.go
@@ -44,6 +44,18 @@ func TestAddTodoWithEuropeanDates(t *testing.T) {
 	assert.Equal([]string{}, todo.Contexts)
 }
 
+func TestAddEmptyTodo(t *testing.T) {
+	assert := assert.New(t)
+	app := &App{TodoList: &TodoList{}, TodoStore: &MemoryStore{}}
+
+	app.AddTodo("a")
+	app.AddTodo("a      ")
+	app.AddTodo("a\t\t\t\t")
+	app.AddTodo("a\t \t  \t   \t")
+
+	assert.Equal(len(app.TodoList.Data), 0)
+}
+
 func TestListbyProject(t *testing.T) {
 	assert := assert.New(t)
 	app := &App{TodoList: &TodoList{}, TodoStore: &MemoryStore{}}

--- a/todolist/parser.go
+++ b/todolist/parser.go
@@ -12,7 +12,7 @@ import (
 type Parser struct{}
 
 func (p *Parser) ParseNewTodo(input string) *Todo {
-	r, _ := regexp.Compile(`^(add|a)(\\ |) `)
+	r, _ := regexp.Compile(`^(add|a)(\s*|)`)
 	input = r.ReplaceAllString(input, "")
 	if input == "" {
 		return nil


### PR DESCRIPTION
This patch fixes #92 .  The new pattern now does not allow empty todos to be added as "a"
or "add" strings.