### PR TITLE
Fix listing overdue tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -25,3 +25,9 @@ task :build do
     `rm -rf dist/#{Version}/todolist`
   end
 end
+
+task :test do
+  system "go test ./..."
+end
+
+task default: :test

--- a/todolist/date_filter.go
+++ b/todolist/date_filter.go
@@ -28,6 +28,11 @@ func (f *DateFilter) FilterDate(input string) []*Todo {
 		return f.filterAgenda(bod(time.Now()))
 	}
 
+	overdueRegex, _ := regexp.Compile(`overdue.*$`)
+	if overdueRegex.MatchString(input) {
+		return f.filterOverdue(bod(time.Now()))
+	}
+
 	// filter due items
 	r, _ := regexp.Compile(`due .*$`)
 	match := r.FindString(input)
@@ -56,8 +61,6 @@ func (f *DateFilter) FilterDate(input string) []*Todo {
 		return f.filterNextWeek(bod(time.Now()))
 	case match == "due last week":
 		return f.filterLastWeek(bod(time.Now()))
-	case match == "overdue":
-		return f.filterOverdue(bod(time.Now()))
 	}
 
 	// filter completed items

--- a/todolist/date_filter_test.go
+++ b/todolist/date_filter_test.go
@@ -7,6 +7,22 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestFilterDateOverdue(t *testing.T) {
+	assert := assert.New(t)
+
+	var todos []*Todo
+	todayTodo := &Todo{Id: 1, Subject: "one", Due: time.Now().Format("2006-01-02")}
+	yesterdayTodo := &Todo{Id: 2, Subject: "two", Due: time.Now().AddDate(0, 0, -1).Format("2006-01-02")}
+	todos = append(todos, todayTodo)
+	todos = append(todos, yesterdayTodo)
+
+	filter := NewDateFilter(todos)
+	filtered := filter.FilterDate("overdue")
+
+	assert.Equal(1, len(filtered))
+	assert.Equal(filtered[0].Id, yesterdayTodo.Id)
+}
+
 func TestFilterToday(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
This bug was because the regex we're using to determine filtering by a date
is expecting to see `due <something>`.  `overdue` was part of that switch
statement.

I pushed `overdue` up to be part of the "special cases" (with "agenda"), so
that it will run the `filterOverdue` logic before going into the big switch
statement.

I found that testing this in the real-world was hard.

closes #101