### PR TITLE
Fix bootstrap theme download URL.

### DIFF
--- a/todolist/webapp.go
+++ b/todolist/webapp.go
@@ -43,7 +43,7 @@ func IndexScaffold(w http.ResponseWriter, r *http.Request, _ httprouter.Params) 
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <link rel="stylesheet" href="https://bootswatch.com/flatly/bootstrap.min.css">
+    <link rel="stylesheet" href="https://bootswatch.com/4/flatly/bootstrap.min.css">
     <title>Todolist</title>
     <link href="` + urlFor("main.css") + `" rel="stylesheet">
   </head>
@@ -64,7 +64,7 @@ func RedirectScaffold(w http.ResponseWriter, r *http.Request) {
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <link rel="stylesheet" href="https://bootswatch.com/flatly/bootstrap.min.css">
+    <link rel="stylesheet" href="https://bootswatch.com/4/flatly/bootstrap.min.css">
     <title>Todolist</title>
     <link href="` + urlFor("main.css") + `" rel="stylesheet">
   </head>

--- a/todolist/webapp.go
+++ b/todolist/webapp.go
@@ -43,7 +43,7 @@ func IndexScaffold(w http.ResponseWriter, r *http.Request, _ httprouter.Params) 
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <link rel="stylesheet" href="https://bootswatch.com/4/flatly/bootstrap.min.css">
+    <link rel="stylesheet" href="https://bootswatch.com/3/flatly/bootstrap.min.css">
     <title>Todolist</title>
     <link href="` + urlFor("main.css") + `" rel="stylesheet">
   </head>
@@ -64,7 +64,7 @@ func RedirectScaffold(w http.ResponseWriter, r *http.Request) {
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1">
-    <link rel="stylesheet" href="https://bootswatch.com/4/flatly/bootstrap.min.css">
+    <link rel="stylesheet" href="https://bootswatch.com/3/flatly/bootstrap.min.css">
     <title>Todolist</title>
     <link href="` + urlFor("main.css") + `" rel="stylesheet">
   </head>


### PR DESCRIPTION
https://bootswatch.com/flatly/bootstrap.min.css doesn't exist anymore and there is no proper redirect to the current version.

This is the new URL https://bootswatch.com/4/flatly/bootstrap.min.css