### PR TITLE
Fix formatting by using 10 spaces for dates

### DIFF
--- a/todolist/screen_printer.go
+++ b/todolist/screen_printer.go
@@ -70,7 +70,7 @@ func (f *ScreenPrinter) formatDue(due string, isPriority bool) string {
 	}
 
 	if due == "" {
-		return blue.SprintFunc()(" ")
+		return blue.SprintFunc()("          ")
 	}
 	dueTime, err := time.Parse("2006-01-02", due)
 
@@ -81,13 +81,13 @@ func (f *ScreenPrinter) formatDue(due string, isPriority bool) string {
 	}
 
 	if isToday(dueTime) {
-		return blue.SprintFunc()("today")
+		return blue.SprintFunc()("today     ")
 	} else if isTomorrow(dueTime) {
-		return blue.SprintFunc()("tomorrow")
+		return blue.SprintFunc()("tomorrow  ")
 	} else if isPastDue(dueTime) {
-		return red.SprintFunc()(dueTime.Format("Mon Jan 2"))
+		return red.SprintFunc()(dueTime.Format("Mon Jan 02"))
 	} else {
-		return blue.SprintFunc()(dueTime.Format("Mon Jan 2"))
+		return blue.SprintFunc()(dueTime.Format("Mon Jan 02"))
 	}
 }
 


### PR DESCRIPTION
This should fix most formatting issues, by forcing the date column to
always use 10 spaces.

One caveat is that dates will now use the format of `Fri Jul 08` instead
of the current `Fri Jul 8`.

How it looks currently in `master`:
![image](https://user-images.githubusercontent.com/38560/43676533-617c36f8-97c1-11e8-804d-2859cd207eb3.png)


How this fix makes it look:
![image](https://user-images.githubusercontent.com/38560/43676545-7d5f7df8-97c1-11e8-8623-430e32b24344.png)
